### PR TITLE
Proposed bugfix for when a bond-breaker offers _more_ ether than the bond balance.

### DIFF
--- a/contracts/BreakableBond.sol
+++ b/contracts/BreakableBond.sol
@@ -49,9 +49,9 @@ contract BreakableBond {
             party2balance = 0;
             status = Status.Broken;
         } else if (msg.value >= party1balance + party2balance) {
-            party1.send(party1balance * 2);
+            party1.send(party1balance + (msg.value * party1balance/(party1balance + party2balance)));
             party1balance = 0;
-            party2.send(party2balance * 2);
+            party2.send(party1balance + (msg.value * party2balance/(party1balance + party2balance)));
             party2balance = 0;
             status = Status.Broken;
         }


### PR DESCRIPTION
In the case where msg.value is strictly greater than the bond balance (though it seems unlikely that a bond breaker would wish to spend more Ether than they have to, but it is technically possible...) there would be
an unspent amount left. This proposal aims to correct that situation.
